### PR TITLE
Add stackable log context

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,25 +1,127 @@
-========================
- Django Context Logging
-========================
-
 .. image:: https://travis-ci.org/lorehov/django_context_logging.svg
     :target: https://travis-ci.org/lorehov/django_context_logging
     :alt: Build Status
 
-=======
- About
-=======
+########################
+ Django Context Logging
+########################
 
-``django_context_logging`` is a library for adding request context to logs.
-Typical usage is for adding some request_id to all logs in order to make
-troubleshooting more comfortable.
+``django_context_logging`` is a library for enriching logs records with context
+fields.  Typical usage is for adding some request_id to all logs in order to
+make troubleshooting more comfortable. This context is shared by all app using
+``logging``, transparently.
 
 
 =======
  Usage
 =======
 
-First enable middleware for storing request context.
+You have two option to send the context to the log system: inject context as
+extra fields in records or append context to the each message.
+
+Using filter
+============
+
+This method allow to pass fields to JSON formatters, log servers, etc. or use
+the extra fields in format string.
+
+.. code-block::
+
+    LOGGING = {
+        'version': 1,
+        'formatters': {
+            'extra': {
+                'format': '%(levelname)s %(rid)s %(name)s %(message)s',
+            },
+        },
+        'filters': {
+            'context_filter': {
+                '()': 'django_context_logging.AddContextFilter',
+                'default': {'rid': None},
+            }
+        },
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'filters': ['context_filter'],
+            },
+        },
+        'root': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+    }
+
+Note three things:
+
+* ``%(rid)`` in format string is for logging rid (for request_id) from our
+  context;
+* ``django_context_logging.AddContextFilter`` - filter which converts keys from
+  context dict to attributes of LogRecord;
+* ``'default': {'rid': None}`` - some of our log events could be without
+  context for example logs emitted on worker start. All these logs will not be
+  recorded due to the lack of 'rid' attribute (in our example) on LogRecord
+  instance. To fix this we provide default value for 'rid'.
+
+
+Using formatter
+===============
+
+If you do not want to bother with custom log format and default context values
+for a filter - you can use ``django_context_logging.AddContextFormatter``.
+
+.. code-block::
+
+    LOGGING = {
+        'version': 1,
+        'formatters': {
+            'append': {
+                '()': 'django_context_logging.AddContextFormatter'
+                'format': '%(levelname)s %(name)s %(message)s'
+            },
+        },
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'formatter': 'append',
+            },
+        },
+        'root': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+    }
+
+As you can see in this case we doesn't add any context related fields to a log
+format string.  This is because ``django_context_logging.AddContextFormatter``
+will append all context information to every log.
+
+
+Feeding the context
+===================
+
+The context class is just a thread local dict. It is used as local registry to
+inject shared fields in log records. Here is a full example:
+
+.. code-block::
+
+   from django_context_logging.log import context as log_context
+
+
+   log_context.push(userId=user.pk)
+   # code, log, etc.
+   for article in blog.articles:
+       with log_context(articleId=article.pk):
+           # code, log, ...
+   # code, log, etc.
+   log_context.pop('userId')
+
+
+Automatic feeding with middleware
+---------------------------------
+
+A middleware is provided to inject extra fields in context. It will also clear
+the context after each requests.
 
 .. code-block::
 
@@ -36,82 +138,3 @@ django.http.request.HttpRequest and returns dictionary with extracted context.
 
 **Note:** ExtractRequestContextMiddleware will fail with exception if no
  DJANGO_CONTEXT_LOGGING_EXTRACTOR specified.
-
-Now it is possible to configure logging in one of two possible ways.
-
-Using filter
-============
-
-.. code-block::
-
-    LOGGING = {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            'verbose': {
-                'format': '%(levelname)s %(asctime)s %(process)d %(rid)s %(name)s %(message)s'
-            },
-        },
-        'filters': {
-            'context_filter': {
-                '()': 'django_context_logging.AddContextFilter',
-                'default': {'rid': None}
-            }
-        },
-        'handlers': {
-            'file': {
-                'level': 'DEBUG',
-                'class': 'logging.FileHandler',
-                'filename': '/path/to/django/debug.log',
-                'filters': ['context_filter']
-            },
-        },
-        'loggers': {
-            '': {
-                'handlers': ['file'],
-                'level': 'DEBUG'
-            },
-        }
-    }
-
-Note three things:
-
-  * ``%(rid)`` in format string is for logging rid (for request_id) from our context;
-  * ``django_context_logging.AddContextFilter`` - filter which converts keys from context dict to attributes of LogRecord;
-  *  ``'default': {'rid': None}`` - some of our log events could be without context for example logs emitted on worker start. All these logs will not be recorded due to the lack of 'rid' attribute (in our example) on LogRecord instance. To fix this we provide default value for 'rid'.
-
-Using formatter
-===============
-
-If you do not want to bother with custom log format and default context values
-for a filter - you can use ``django_context_logging.AddContextFormatter``.
-
-.. code-block::
-
-    LOGGING = {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'formatters': {
-            'verbose': {
-                '()': 'django_context_logging.AddContextFormatter'
-                'format': '%(levelname)s %(asctime)s %(process)d %(name)s %(message)s'
-            },
-        },
-        'handlers': {
-            'file': {
-                'level': 'DEBUG',
-                'class': 'logging.FileHandler',
-                'filename': '/path/to/django/debug.log',
-            },
-        },
-        'loggers': {
-            '': {
-                'handlers': ['file'],
-                'level': 'DEBUG'
-            },
-        }
-    }
-
-As you can see in this case we doesn't add any context related fields to a log
-format string.  This is because ``django_context_logging.AddContextFormatter``
-will append all context information to every log.


### PR DESCRIPTION
Hi,

I now start to propose all the features i have implemented in-house :-) The code is live since october 2015. I adapted it to your code, and migrated test case to pytest.

The first step i identified is to make the log context a full object, singleton (per thread), that can be fed or empty on demand by each part of the code. For example:

 - `app.ready` inject env tag (staging vs prod), app name or even app version
 - middleware inject request id, tenant id, user id on login, etc.
 - code add / remove extra field. We use this to track life of objects accross app. (ex: document, article, etc.)

Let me know your opinion ! :-)

I have code to add celery task id in log context to trace fullstack logs of a task run. PR is comming ;-)